### PR TITLE
import the upstream absolute filename fix, closes #12

### DIFF
--- a/debian/patches/0008-upstream-absolute-filename.patch
+++ b/debian/patches/0008-upstream-absolute-filename.patch
@@ -1,0 +1,29 @@
+## Based on 
+## https://github.com/OpenNI/OpenNI2/commit/86efc7a
+
+--- a/ThirdParty/PSCommon/XnLib/Source/Linux/XnLinuxSharedLibs.cpp
++++ b/ThirdParty/PSCommon/XnLib/Source/Linux/XnLinuxSharedLibs.cpp
+@@ -34,9 +34,20 @@
+ 	XN_VALIDATE_INPUT_PTR(cpFileName);
+ 	XN_VALIDATE_OUTPUT_PTR(pLibHandle);
+ 
++	// Resolve the file name to the absolute path. This is necessary because
++	// we need to get the absolute path of this library by dladdr() later.
++	// Note dladdr() seems to return the path specified to dlopen() "as it is".
++	XnChar* strAbsoluteFileName = realpath(cpFileName, NULL);
++	if (strAbsoluteFileName == NULL) {
++		// error
++		xnLogWarning(XN_MASK_OS, "Failed to get absolute path for lib: %s\n", cpFileName);
++		return XN_STATUS_OS_CANT_LOAD_LIB;
++	}
++
+ 	// Load the requested shared library via the OS
+-	*pLibHandle = dlopen(cpFileName, RTLD_NOW);
+-	
++	*pLibHandle = dlopen(strAbsoluteFileName, RTLD_NOW);
++	free(strAbsoluteFileName); // Don't forget to free the memory allocated by realpath().
++
+ 	// Make sure it succeeded (return value is not NULL). If not return an error....
+ 	if (*pLibHandle == NULL)
+ 	{
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@
 0006-rpi-Added-Armv6l-as-new-target-platform-and-created-missing-OniPlatformLinux-Arm.h-header.patch
 0006-Disable-SSE.patch
 0007-Link-NiViewer-against-ptherad-DSO-on-Ubuntu-raring.patch
+0008-upstream-absolute-filename.patch


### PR DESCRIPTION
This is a patch found in the upstream OpenNI2 sources, from after our branch was created. In the patch, I've left a reference to the actual commit that I pulled this patch from.

I've built a debian, installed on 12.04, and tested that my installed openni2_camera works against it with Asus Xtion Pro Live, Primesense 1.082 and Primesense 1.09.
